### PR TITLE
New config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Much quicker than current Zim search.
 
 ### Working with & Feedback
 Known to work on Ubuntu 17.04 Zim 0.67+, Ubuntu 15.10 Zim 0.65+, Win 7 Zim 0.63+.  
-(For **earlier version than Zim 0.66-** use an old commit from Mar 17, not the current version.)  
+(For **earlier version than Zim 0.66-**, open the plugin configuration window for Instant Search and enable the option for using Zim version earlier than 0.66-, or use an old Instant Search commit from Mar 17 instead of the current version.)
 I'd be glad to hear from you if it's working either here in the issues or in the original bug https://bugs.launchpad.net/zim/+bug/1409626 .
 
 ### Installation

--- a/instantsearch.py
+++ b/instantsearch.py
@@ -56,6 +56,7 @@ You can walk through by UP/DOWN arrow, hit Enter to stay on the page, or Esc to 
                           ('ignore_subpages', 'bool', _("Ignore subpages (if ignored, search 'linux' would return page:linux but not page:linux:subpage (if in the subpage, there is no occurece of string 'linux')"), True),
                           ('isWildcarded', 'bool', _("Append wildcards to the search string: *string*"), True),
                           ('isCached', 'bool', _("Cache results of a search to be used in another search. (Till the end of zim process.)"), True),
+                          ('open_when_unique', 'bool', _('When only one page is found, open it automatically.'), True),
                           ('position', 'choice', _('Popup position'), POSITION_RIGHT, (POSITION_RIGHT, POSITION_CENTER))
                           # T: plugin preference
                           )
@@ -102,6 +103,7 @@ class InstantsearchMainWindowExtension(WindowExtension):
         self.title_match_char = self.plugin.preferences['title_match_char']
         self.start_search_length = self.plugin.preferences['start_search_length']
         self.keystroke_delay = self.plugin.preferences['keystroke_delay']
+        self.open_when_unique = self.plugin.preferences['open_when_unique']
 
         # building quick title cache
         def build(start = ""):
@@ -240,9 +242,10 @@ class InstantsearchMainWindowExtension(WindowExtension):
 
     def checkLast(self):
         """ opens the page if there is only one option in the menu """
-        if len(self.state.menu) == 1:
-            self._open_page(Path(self.state.menu.keys()[0]), excludeFromHistory=False)
-            self.close()
+        if self.open_when_unique is True:
+            if len(self.state.menu) == 1:
+                self._open_page(Path(self.state.menu.keys()[0]), excludeFromHistory=False)
+                self.close()
 
     def _search_callback(self, query):
         def _search_callback(results, path):

--- a/instantsearch.py
+++ b/instantsearch.py
@@ -57,6 +57,7 @@ You can walk through by UP/DOWN arrow, hit Enter to stay on the page, or Esc to 
                           ('isWildcarded', 'bool', _("Append wildcards to the search string: *string*"), True),
                           ('isCached', 'bool', _("Cache results of a search to be used in another search. (Till the end of zim process.)"), True),
                           ('open_when_unique', 'bool', _('When only one page is found, open it automatically.'), True),
+                          ('old_zim', 'bool', _('Check this option if using Zim version earlier than 0.66-.'), False),
                           ('position', 'choice', _('Popup position'), POSITION_RIGHT, (POSITION_RIGHT, POSITION_CENTER))
                           # T: plugin preference
                           )
@@ -104,13 +105,31 @@ class InstantsearchMainWindowExtension(WindowExtension):
         self.start_search_length = self.plugin.preferences['start_search_length']
         self.keystroke_delay = self.plugin.preferences['keystroke_delay']
         self.open_when_unique = self.plugin.preferences['open_when_unique']
+        self.old_zim = self.plugin.preferences['old_zim']
 
         # building quick title cache
         def build(start = ""):
-            for s in self.window.ui.notebook.pages.list_pages(Path(start or ":")):
-                start2 = (start + ":" if start else "") + s.basename
-                self.cached_titles.append((start2, start2.lower()))
-                build(start2)
+            if self.old_zim is False:
+                for s in self.window.ui.notebook.pages.list_pages(Path(start or ":")):
+                    start2 = (start + ":" if start else "") + s.basename
+                    self.cached_titles.append((start2, start2.lower()))
+                    build(start2)
+            else:
+                for s in self.window.ui.notebook.index.list_pages(Path(':')):
+                    st = s.basename
+                    self.cached_titles.append((st, st.lower()))
+                    for s2 in self.window.ui.notebook.get_pagelist(Path(st)):
+                        st = s.basename + ":" + s2.basename
+                        self.cached_titles.append((st, st.lower()))
+                        for s3 in self.window.ui.notebook.get_pagelist(Path(st)):
+                            st = s.basename + ":" + s2.basename + ":" + s3.basename
+                            self.cached_titles.append((st, st.lower()))
+                            for s4 in self.window.ui.notebook.get_pagelist(Path(st)):
+                                st = s.basename + ":" + s2.basename + ":" + s3.basename + ":" + s4.basename
+                                self.cached_titles.append((st, st.lower()))
+                                for s5 in self.window.ui.notebook.get_pagelist(Path(st)):
+                                    st = s.basename + ":" + s2.basename + ":" + s3.basename + ":" + s4.basename + ":" + s5.basename
+                                    self.cached_titles.append((st, st.lower()))
         build()
 
         # Gtk

--- a/instantsearch.py
+++ b/instantsearch.py
@@ -353,11 +353,11 @@ class InstantsearchMainWindowExtension(WindowExtension):
     def move(self, widget, event):
         """ Move caret up and down. Enter to confirm, Esc closes search."""
         keyname = gtk.gdk.keyval_name(event.keyval)
-        if keyname == "Up":
+        if keyname == "Up" or keyname == "ISO_Left_Tab":
             self.caret['pos'] -= 1
             self.soutMenu(displayImmediately=False)
 
-        if keyname == "Down":
+        if keyname == "Down" or keyname == "Tab":
             self.caret['pos'] += 1
             self.soutMenu(displayImmediately=False)
 


### PR DESCRIPTION
I've added two new config options that I find useful.

The first allows the user to prevent Instant Search from automatically opening a page when it is the only one found for the query. I find that with this behavior is enabled, I always end up accidentally editing the page because I'm still typing my query when it's opened (because I always leave the notebook in edit mode rather than read-only mode).

The second allows Instant Search to work with versions of Zim earlier than 0.66-. Debian Stretch uses Zim 0.65-4 and I'm still running Jessie anyway, so this seems like a useful option for saving Debian users from having to use an old Instant Search commit.