### PR TITLE
Use the correct file encoding

### DIFF
--- a/instantsearch.py
+++ b/instantsearch.py
@@ -379,7 +379,13 @@ class InstantSearchMainWindowExtension(MainWindowExtension):
 
         for path in paths:
             if path not in file_cache:
-                contents = path.read_text()  # strip header
+                try:
+                    contents = path.read_text(encoding='UTF-8') 
+                except UnicodeDecodeError as err:
+                    # Ignore file an skip to next path
+                    logger.warning("Skipping path %s due to invalid character encoding error: %s", path, err)
+                    continue 
+                # strip header
                 if contents.startswith('Content-Type: text/x-zim-wiki'):
                     # XX will that work on Win?
                     # I should use more general separator IMHO in the whole file rather than '\n'.


### PR DESCRIPTION
Zim uses UTF-8 encoding for accessing notebook files, see https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/89337ddfd8fc7a48906583abca1270e770151186/zim/fs.py#L1156

This change avoids crashing the search when unicode characters are used in any of the notebook files.

Relates to https://github.com/e3rd/zim-plugin-instantsearch/issues/45#issuecomment-998336993 and perhaps partially fixes #45